### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ RESOLVER_GATEWAY_URL_TEST = '/{bibcode}/{link_type}/{url}'
 RESOLVER_DETERMINISTIC_LINKS_BASEURL = '/#abs'
 
 # These URLs are used to create links for doi and arXiv sources
-RESOLVER_DOI_LINK_BASEURL = 'http://dx.doi.org/{id}'
+RESOLVER_DOI_LINK_BASEURL = 'https://doi.org/{id}'
 RESOLVER_ARXIV_LINK_BASEURL = 'http://arxiv.org/abs/{id}'
 
 RESOLVER_DATA_SOURCES = {

--- a/resolversrv/tests/unittests/test_db_query.py
+++ b/resolversrv/tests/unittests/test_db_query.py
@@ -69,7 +69,7 @@ class test_database(TestCase):
         stub_data = [
                         ('2013MNRAS.435.1904M', 'ESOURCE',      'EPRINT_HTML', ['http://arxiv.org/abs/1307.6556'], [''], 0),
                         ('2013MNRAS.435.1904M', 'ESOURCE',      'EPRINT_PDF',  ['http://arxiv.org/pdf/1307.6556'], [''], 0),
-                        ('2013MNRAS.435.1904M', 'ESOURCE',      'PUB_HTML',    ['http://dx.doi.org/10.1093%2Fmnras%2Fstt1379'], [''], 0),
+                        ('2013MNRAS.435.1904M', 'ESOURCE',      'PUB_HTML',    ['https://doi.org/10.1093%2Fmnras%2Fstt1379'], [''], 0),
                         ('2013MNRAS.435.1904M', 'ESOURCE',      'PUB_PDF',     ['http://mnras.oxfordjournals.org/content/435/3/1904.full.pdf'], [''], 0),
                         ('2013MNRAS.435.1904M', 'DATA',         'CXO',         ['http://cda.harvard.edu/chaser?obsid=494'], ['Chandra Data Archive ObsIds 494'], 27),
                         ('2013MNRAS.435.1904M', 'DATA',         'ESA',         ['http://archives.esac.esa.int/ehst/#bibcode=2013MNRAS.435.1904M'], ['European HST References (EHST)'], 1),
@@ -288,7 +288,7 @@ class test_database(TestCase):
                           "links": {"count": 4, "link_type": "ESOURCE", "bibcode": "2013MNRAS.435.1904", "records": [
                              {"url": "http://arxiv.org/abs/1307.6556", "title": "http://arxiv.org/abs/1307.6556"},
                              {"url": "http://arxiv.org/pdf/1307.6556", "title": "http://arxiv.org/pdf/1307.6556"},
-                             {"url": "http://dx.doi.org/10.1093%2Fmnras%2Fstt1379", "title": "http://dx.doi.org/10.1093%2Fmnras%2Fstt1379"},
+                             {"url": "https://doi.org/10.1093%2Fmnras%2Fstt1379", "title": "https://doi.org/10.1093%2Fmnras%2Fstt1379"},
                              {"url": "http://mnras.oxfordjournals.org/content/435/3/1904.full.pdf", "title": "http://mnras.oxfordjournals.org/content/435/3/1904.full.pdf"}]},
                           "service": ""})
 

--- a/resolversrv/tests/unittests/test_with_no_db_required.py
+++ b/resolversrv/tests/unittests/test_with_no_db_required.py
@@ -246,7 +246,7 @@ class test_with_no_database_required(TestCase):
         """
         response = LinkRequest(bibcode='2010ApJ...713L.103B', link_type='DOI', id='10.1088/2041-8205/713/2/L103').process_request()
         self.assertEqual(response._status_code, 200)
-        self.assertEqual(response.response[0], '{"action": "redirect", "link": "http://dx.doi.org/10.1088/2041-8205/713/2/L103", "link_type": "DOI", "service": "http://dx.doi.org/10.1088/2041-8205/713/2/L103"}')
+        self.assertEqual(response.response[0], '{"action": "redirect", "link": "https://doi.org/10.1088/2041-8205/713/2/L103", "link_type": "DOI", "service": "https://doi.org/10.1088/2041-8205/713/2/L103"}')
 
         response = LinkRequest(bibcode='2018arXiv180303598K', link_type='ARXIV', id='1803.03598').process_request()
         self.assertEqual(response._status_code, 200)


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

Cheers